### PR TITLE
allow for ipv6 addresses

### DIFF
--- a/lib/eviler_winrm/connection.rb
+++ b/lib/eviler_winrm/connection.rb
@@ -34,6 +34,7 @@ module EvilerWinRM
       proto = args[:ssl] ? 'https' : 'http'
       endpoint = args[:url].delete_prefix('/')
       port = args[:port] || (args[:ssl] ? 5986 : 5985)
+      ip = ip.match?(Resolv::IPv6::Regex) ? "[#{ip}]" : ip
       url = format('%s://%s:%i/%s', proto, ip, port, endpoint)
 
       if args[:ssl]


### PR DESCRIPTION
fixes an issue where ipv6 addresses were not properly encapsulated in square brackets which would lead to connection failure.